### PR TITLE
【確認待ち】ブロックサポートのためにwrapper_attributesを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $vk_breadcrumb->the_breadcrumb( $breadcrumb_options );
 
 ## Change log
 
+0.2.0
 [ Specification Change ] Add option to wrapper_attributes method for Gutenberg.
 
 0.1.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $vk_breadcrumb->the_breadcrumb( $breadcrumb_options );
 [ Specification Change ] Add option to wrapper_attributes method for Gutenberg.
 
 0.1.0
-[ Spacification Change ] Add get_breadcrumb() method
+[ Specification Change ] Add get_breadcrumb() method
 
 0.0.5 
 [ Bug fix ] id が class_outer になってしまっていたので修正

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ $vk_breadcrumb->the_breadcrumb( $breadcrumb_options );
 
 ## Change log
 
+[ Specification Change ] Add option to wrapper_attributes method for Gutenberg.
+
 0.1.0
 [ Spacification Change ] Add get_breadcrumb() method
 

--- a/src/VkBreadcrumb.php
+++ b/src/VkBreadcrumb.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-breadcrumb
  * @license GPL-2.0+
  *
- * @version 0.1.0
+ * @version 0.2.0
  */
 
 namespace VektorInc\VK_Breadcrumb;
@@ -378,7 +378,7 @@ class VkBreadcrumb {
 		$microdata_li_a      = ' itemprop="item"';
 		$microdata_li_a_span = ' itemprop="name"';
 
-		$breadcrumb_html  = '<!-- [ #' . esc_attr( $options['class_outer'] ) . ' ] -->';
+		$breadcrumb_html = '<!-- [ #' . esc_attr( $options['class_outer'] ) . ' ] -->';
 		if ( ! empty( $options['wrapper_attributes'] ) ) {
 			$breadcrumb_html .= '<div id="' . esc_attr( $options['id_outer'] ) . '" ' . $options['wrapper_attributes'] . '>';
 		} else {

--- a/src/VkBreadcrumb.php
+++ b/src/VkBreadcrumb.php
@@ -358,11 +358,12 @@ class VkBreadcrumb {
 
 		if ( ! $options ) {
 			$options = array(
-				'id_outer'        => 'breadcrumb',
-				'class_outer'     => 'breadcrumb',
-				'class_inner'     => 'container',
-				'class_list'      => 'breadcrumb-list',
-				'class_list_item' => 'breadcrumb-list__item',
+				'id_outer'           => 'breadcrumb',
+				'class_outer'        => 'breadcrumb',
+				'wrapper_attributes' => '',
+				'class_inner'        => 'container',
+				'class_list'         => 'breadcrumb-list',
+				'class_list_item'    => 'breadcrumb-list__item',
 			);
 		}
 
@@ -378,7 +379,11 @@ class VkBreadcrumb {
 		$microdata_li_a_span = ' itemprop="name"';
 
 		$breadcrumb_html  = '<!-- [ #' . esc_attr( $options['class_outer'] ) . ' ] -->';
-		$breadcrumb_html .= '<div id="' . esc_attr( $options['id_outer'] ) . '" class="' . esc_attr( $options['class_outer'] ) . '">';
+		if ( $options['wrapper_attributes'] ) {
+			$breadcrumb_html .= '<div id="' . esc_attr( $options['id_outer'] ) . '" ' . $options['wrapper_attributes'] . '>';
+		} else {
+			$breadcrumb_html .= '<div id="' . esc_attr( $options['id_outer'] ) . '" class="' . $options['class_outer'] . '">';
+		}
 		$breadcrumb_html .= '<div class="' . esc_attr( $options['class_inner'] ) . '">';
 		$breadcrumb_html .= '<ol class="' . esc_attr( $options['class_list'] ) . '" itemscope itemtype="https://schema.org/BreadcrumbList">';
 

--- a/src/VkBreadcrumb.php
+++ b/src/VkBreadcrumb.php
@@ -379,7 +379,7 @@ class VkBreadcrumb {
 		$microdata_li_a_span = ' itemprop="name"';
 
 		$breadcrumb_html  = '<!-- [ #' . esc_attr( $options['class_outer'] ) . ' ] -->';
-		if ( $options['wrapper_attributes'] ) {
+		if ( ! empty( $options['wrapper_attributes'] ) ) {
 			$breadcrumb_html .= '<div id="' . esc_attr( $options['id_outer'] ) . '" ' . $options['wrapper_attributes'] . '>';
 		} else {
 			$breadcrumb_html .= '<div id="' . esc_attr( $options['id_outer'] ) . '" class="' . $options['class_outer'] . '">';

--- a/src/VkBreadcrumb.php
+++ b/src/VkBreadcrumb.php
@@ -429,10 +429,9 @@ class VkBreadcrumb {
 		}
 
 			$breadcrumb_html .= '</ol>';
-			$breadcrumb_html .= '</div>
-			</div>
-			<!-- [ /#' . esc_attr( $options['class_outer'] ) . ' ] -->
-			';
+			$breadcrumb_html .= '</div>';
+			$breadcrumb_html .= '</div>';
+			$breadcrumb_html .= '<!-- [ /#' . esc_attr( $options['class_outer'] ) . ' ] -->';
 			$breadcrumb_html  = apply_filters( 'vk_breadcrumb_html', $breadcrumb_html );
 			return $breadcrumb_html;
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由
https://github.com/vektor-inc/vk-blocks-pro/issues/1108
 
## どういう変更をしたか？
`wrapper_attributes`が存在したらwrapper_attributesを追加する実装を追加
 
## 確認事項
こちらのプルリクに書きました
https://github.com/vektor-inc/vk-blocks-pro/pull/1167