### PR TITLE
Font Awesome 7 に対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npm run phpunit
 
 ## Change log
 
+[ Other ] アイコンを Font Awesome 7 に対応
+
 0.2.8
 [ Other ] VkHelpers を static メソッドとして呼び出すように変更
 

--- a/src/VkBreadcrumb.php
+++ b/src/VkBreadcrumb.php
@@ -47,7 +47,7 @@ class VkBreadcrumb {
 				'id'    => '',
 				'url'   => home_url(),
 				'class' => 'breadcrumb-list__item--home',
-				'icon'  => 'fas fa-fw fa-home',
+				'icon'  => 'fa-solid fa-fw fa-house',
 			),
 		);
 

--- a/tests/test-vk-breadcrumb.php
+++ b/tests/test-vk-breadcrumb.php
@@ -136,7 +136,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => __( 'Not found', 'lightning' ),
@@ -156,7 +156,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => __( 'Search Results', 'lightning' ),
@@ -177,7 +177,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => sprintf( __( 'Search Results for : %s', 'lightning' ), 'aaa' ),
@@ -204,7 +204,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 				),
 			),
@@ -218,7 +218,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'parent_page',
@@ -245,7 +245,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'parent_page',
@@ -272,7 +272,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'parent_page',
@@ -301,7 +301,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'parent_page',
@@ -333,7 +333,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'parent_category',
@@ -365,7 +365,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'parent_category',
@@ -406,7 +406,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'post_top',
@@ -433,7 +433,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'post_top',
@@ -474,7 +474,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'post_top',
@@ -508,7 +508,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'post_top',
@@ -540,7 +540,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'Year: <span>' . date( 'Y' ) . '</span>',
@@ -562,7 +562,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'Event',
@@ -584,7 +584,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'Event',
@@ -613,7 +613,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'Event',
@@ -642,7 +642,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'Event',
@@ -678,7 +678,7 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 						'id'    => '',
 						'url'   => home_url(),
 						'class' => 'breadcrumb-list__item--home',
-						'icon'  => 'fas fa-fw fa-home',
+						'icon'  => 'fa-solid fa-fw fa-house',
 					),
 					array(
 						'name'  => 'Search Results for : test',


### PR DESCRIPTION
パンくずの Home の部分のアイコンを Font Awesome 7 のものに変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Changelog に Font Awesome 7 への対応に関する情報を追記しました。

* **改善**
  * アイコン表示を最新の Font Awesome 仕様に対応させました。ホームアイコンの表現を更新し、テストデータも併せて更新しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->