### PR TITLE
[ 開発環境 ] vk-helpers の require を ^0.2.1 || ^0.3.0 に緩和

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm run phpunit
 ## Change log
 
 [ Other ] アイコンを Font Awesome 7 に対応
+[ 開発環境 ] vk-helpers の require を ^0.2.1 || ^0.3.0 に緩和
 
 0.2.8
 [ Other ] VkHelpers を static メソッドとして呼び出すように変更

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"vektor-inc/vk-helpers": "^0.2.1"
+		"vektor-inc/vk-helpers": "^0.2.1 || ^0.3.0"
 	},
 	"require-dev": {
 		"wp-phpunit/wp-phpunit": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05f051fc3ea9d48e46a20ba9793b8982",
+    "content-hash": "9c710b654e7f416de5daab86d7cb187e",
     "packages": [
         {
             "name": "vektor-inc/vk-helpers",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/vk-helpers.git",
-                "reference": "991e8da04652f999ef95eb90e34bacd4ec5dbf52"
+                "reference": "f1b327a06a1f543b4b4c6694501b8da7c1f0326b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/vk-helpers/zipball/991e8da04652f999ef95eb90e34bacd4ec5dbf52",
-                "reference": "991e8da04652f999ef95eb90e34bacd4ec5dbf52",
+                "url": "https://api.github.com/repos/vektor-inc/vk-helpers/zipball/f1b327a06a1f543b4b4c6694501b8da7c1f0326b",
+                "reference": "f1b327a06a1f543b4b4c6694501b8da7c1f0326b",
                 "shasum": ""
             },
             "require-dev": {
@@ -27,6 +27,10 @@
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/VK_Custom_Html_Control.php",
+                    "src/VK_Custom_Text_Control.php"
+                ],
                 "psr-4": {
                     "VektorInc\\VK_Helpers\\": "src/"
                 }
@@ -44,9 +48,9 @@
             "description": "WordPress Helpers Class",
             "support": {
                 "issues": "https://github.com/vektor-inc/vk-helpers/issues",
-                "source": "https://github.com/vektor-inc/vk-helpers/tree/0.2.1"
+                "source": "https://github.com/vektor-inc/vk-helpers/tree/0.3.0"
             },
-            "time": "2025-08-21T01:08:34+00:00"
+            "time": "2026-05-23T08:52:45+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## 背景

vk-helpers 0.3.0 がリリースされましたが、vk-breadcrumb 0.2.8 の composer.json では `"vektor-inc/vk-helpers": "^0.2.1"` で制約されており、vk-helpers 0.3.0 を使用するプロジェクト（ExUnit 等）で vk-breadcrumb と共存できない状態です。

vk-helpers 0.3.0 はカスタマイザー用 control クラス（`VK_Custom_Html_Control` / `VK_Custom_Text_Control`）を追加したのみで、既存 API は完全互換です。

## 変更内容

- `composer.json` の `vektor-inc/vk-helpers` の constraint を `^0.2.1` から `^0.2.1 || ^0.3.0` に緩和
- `composer.lock` を 0.3.0 へ更新（`composer update vektor-inc/vk-helpers`）
- `README.md` の Change log に追記

## 影響

vk-breadcrumb が使用している vk-helpers のメソッドは以下の 2 つのみで、いずれも 0.3.0 にも残存しています。

- `VkHelpers::get_post_type_info()`
- `VkHelpers::get_post_top_info()`

```php
// src/VkBreadcrumb.php:28-30
$post_type_info = VkHelpers::get_post_type_info();
$post_top_info  = VkHelpers::get_post_top_info();
```

ローカルで `composer update vektor-inc/vk-helpers` 実行後、autoload 経由でクラスロードと両メソッドの存在を確認済みです。

```
class OK
get_post_type_info OK
get_post_top_info OK
installed version: 0.3.0
```

## 効果

vk-helpers 0.3.0 を使うプロジェクト（ExUnit 等）で vk-breadcrumb と共存できるようになります。0.2.x 系もそのまま使用可能なので後方互換性は維持されます。

## 確認手順

### 前提条件

- ローカルに本ブランチを clone 済み
- `composer` コマンドが利用可能

### 手順

1. 本ブランチをチェックアウトする
   ```
   git fetch origin chore/relax-vk-helpers-constraint
   git checkout chore/relax-vk-helpers-constraint
   ```
2. composer 依存関係をインストールする
   ```
   composer install
   ```
   → ✓ エラーなく完了する
3. vk-helpers のバージョンを確認する
   ```
   composer show vektor-inc/vk-helpers | grep ^versions
   ```
   → ✓ `versions : * 0.3.0` が表示される
4. PHP syntax チェック
   ```
   php -l src/VkBreadcrumb.php
   ```
   → ✓ `No syntax errors detected`
5. autoload とメソッド存在の確認（PHPUnit 環境構築が手間なため簡易確認）
   ```
   php -r 'require "vendor/autoload.php"; $c="VektorInc\\VK_Helpers\\VkHelpers"; var_dump(class_exists($c), method_exists($c, "get_post_type_info"), method_exists($c, "get_post_top_info"));'
   ```
   → ✓ いずれも `bool(true)`

### デグレ確認

- composer.json で 0.2.x にロックしているプロジェクトはこれまで通り 0.2.x が解決されるため、既存利用者には影響なし

## 補足（他リポジトリの状況）

同じく `vk-helpers: ^0.2.1` で制約しているリポジトリが他にもあります（参考情報）。

- `vektor-inc/vk-blocks`
- `vektor-inc/vk-blocks-pro`
- `vektor-inc/vk-dynamic-if-block`

これらは本 PR のスコープ外ですが、vk-helpers 0.3.0 への移行が進む場合は同様の対応が必要になる可能性があります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 開発環境の依存パッケージの対応バージョン範囲を拡張し、より多くの環境構成での利用が可能になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-breadcrumb/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->