### PR TITLE
[ 機能追加 ] パンくずのナビゲーションランドマーク化と現在ページの明示（nav / aria-current）

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npm run phpunit
 
 ## Change log
 
+[ アクセシビリティ ] パンくずをナビゲーションランドマーク（nav 要素）で囲み、現在ページに aria-current="page" を付与
+
 [ Other ] アイコンを Font Awesome 7 に対応
 [ 開発環境 ] vk-helpers の require を ^0.2.1 || ^0.3.0 に緩和
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ npm run phpunit
 
 ## Change log
 
-[ アクセシビリティ ] パンくずをナビゲーションランドマーク（nav 要素）で囲み、現在ページに aria-current="page" を付与
-
+[ 機能追加 ] パンくずのナビゲーションランドマーク化と現在ページの明示（nav / aria-current）
 [ Other ] アイコンを Font Awesome 7 に対応
 [ 開発環境 ] vk-helpers の require を ^0.2.1 || ^0.3.0 に緩和
 

--- a/src/VkBreadcrumb.php
+++ b/src/VkBreadcrumb.php
@@ -409,7 +409,13 @@ class VkBreadcrumb {
 			}
 			$class .= '"';
 
-			$breadcrumb_html .= '<li' . $id . $class . $microdata_li . '>';
+			// 最後の要素（現在ページ）の <li> に aria-current="page" を付与する。
+			// span ではなく li に付けることで、末端要素がリンク（<a>）を持つ場合でも
+			// 「リンク内の非インタラクティブ子要素に aria-current」という構造を避けられ、
+			// リンクの有無に関わらず「最後のリスト項目＝現在地」が構造的に明確になる。
+			$aria_current_attr = ( $key === $last_key ) ? ' aria-current="page"' : '';
+
+			$breadcrumb_html .= '<li' . $id . $class . $microdata_li . $aria_current_attr . '>';
 
 			if ( $value['url'] ) {
 				$breadcrumb_html .= '<a href="' . esc_url( $value['url'] ) . '"' . $microdata_li_a . '>';
@@ -428,10 +434,7 @@ class VkBreadcrumb {
 				'rt'   => array(),
 			);
 
-			// 最後の要素（現在ページ）のみ aria-current="page" を付与する。
-			$aria_current_attr = ( $key === $last_key ) ? ' aria-current="page"' : '';
-
-			$breadcrumb_html .= '<span' . $microdata_li_a_span . $aria_current_attr . '>' . wp_kses( $value['name'], $breadclumb_post_title_allowed_html ) . '</span>';
+			$breadcrumb_html .= '<span' . $microdata_li_a_span . '>' . wp_kses( $value['name'], $breadclumb_post_title_allowed_html ) . '</span>';
 
 			if ( $value['url'] ) {
 				$breadcrumb_html .= '</a>';
@@ -489,6 +492,8 @@ class VkBreadcrumb {
 				'itemprop'  => array(),
 				'itemscope' => array(),
 				'itemtype'  => array(),
+				// 現在ページを示す aria-current が剥がされないよう許可する。
+				'aria-current' => array(),
 			),
 			'a'    => array(
 				'id'       => array(),
@@ -498,13 +503,11 @@ class VkBreadcrumb {
 				'itemprop' => array(),
 			),
 			'span' => array(
-				'id'          => array(),
-				'class'       => array(),
-				'itemprop'    => array(),
-				'itemscope'   => array(),
-				'itemtype'    => array(),
-				// 現在ページを示す aria-current が剥がされないよう許可する。
-				'aria-current' => array(),
+				'id'        => array(),
+				'class'     => array(),
+				'itemprop'  => array(),
+				'itemscope' => array(),
+				'itemtype'  => array(),
 			),
 			'i'    => array(
 				'id'    => array(),

--- a/src/VkBreadcrumb.php
+++ b/src/VkBreadcrumb.php
@@ -354,7 +354,8 @@ class VkBreadcrumb {
 	/**
 	 * Get Bread Crumb
 	 *
-	 * @param array $options
+	 * @param array $options オプション配列。id_outer / class_outer / wrapper_attributes / class_inner / class_list / class_list_item を指定できる。
+	 * @return string パンくずの HTML 文字列。
 	 */
 	public static function get_breadcrumb( $options = array() ) {
 
@@ -380,7 +381,12 @@ class VkBreadcrumb {
 		$microdata_li_a      = ' itemprop="item"';
 		$microdata_li_a_span = ' itemprop="name"';
 
-		$breadcrumb_html = '<!-- [ #' . esc_attr( $options['class_outer'] ) . ' ] -->';
+		// スクリーンリーダー向けのランドマーク aria-label。翻訳可能かつフィルタで上書き可能にする。
+		$nav_aria_label = apply_filters( 'vk_breadcrumb_nav_aria_label', __( 'Breadcrumb', 'lightning' ) );
+
+		// 最も外側を <nav> で囲み、ナビゲーションランドマークとして識別させる。
+		$breadcrumb_html  = '<nav aria-label="' . esc_attr( $nav_aria_label ) . '">';
+		$breadcrumb_html .= '<!-- [ #' . esc_attr( $options['class_outer'] ) . ' ] -->';
 		if ( ! empty( $options['wrapper_attributes'] ) ) {
 			$breadcrumb_html .= '<div id="' . esc_attr( $options['id_outer'] ) . '" ' . $options['wrapper_attributes'] . '>';
 		} else {
@@ -388,6 +394,9 @@ class VkBreadcrumb {
 		}
 		$breadcrumb_html .= '<div class="' . esc_attr( $options['class_inner'] ) . '">';
 		$breadcrumb_html .= '<ol class="' . esc_attr( $options['class_list'] ) . '" itemscope itemtype="https://schema.org/BreadcrumbList">';
+
+		// パンくず配列の最後のキーを取得。現在ページの判定に使う。
+		$last_key = array_key_last( $breadcrumb_array );
 
 		$position = 0;
 		foreach ( $breadcrumb_array as $key => $value ) {
@@ -418,7 +427,11 @@ class VkBreadcrumb {
 				'ruby' => array(),
 				'rt'   => array(),
 			);
-			$breadcrumb_html                   .= '<span' . $microdata_li_a_span . '>' . wp_kses( $value['name'], $breadclumb_post_title_allowed_html ) . '</span>';
+
+			// 最後の要素（現在ページ）のみ aria-current="page" を付与する。
+			$aria_current_attr = ( $key === $last_key ) ? ' aria-current="page"' : '';
+
+			$breadcrumb_html .= '<span' . $microdata_li_a_span . $aria_current_attr . '>' . wp_kses( $value['name'], $breadclumb_post_title_allowed_html ) . '</span>';
 
 			if ( $value['url'] ) {
 				$breadcrumb_html .= '</a>';
@@ -430,21 +443,32 @@ class VkBreadcrumb {
 
 		}
 
-			$breadcrumb_html .= '</ol>';
-			$breadcrumb_html .= '</div>';
-			$breadcrumb_html .= '</div>';
-			$breadcrumb_html .= '<!-- [ /#' . esc_attr( $options['class_outer'] ) . ' ] -->';
-			$breadcrumb_html  = apply_filters( 'vk_breadcrumb_html', $breadcrumb_html );
-			return $breadcrumb_html;
+		$breadcrumb_html .= '</ol>';
+		$breadcrumb_html .= '</div>';
+		$breadcrumb_html .= '</div>';
+		$breadcrumb_html .= '<!-- [ /#' . esc_attr( $options['class_outer'] ) . ' ] -->';
+		// <nav> ランドマークの閉じタグ。
+		$breadcrumb_html .= '</nav>';
+		$breadcrumb_html  = apply_filters( 'vk_breadcrumb_html', $breadcrumb_html );
+		return $breadcrumb_html;
 
 	}
 
 
 	/**
 	 * Print Bread Crumb
+	 *
+	 * wp_kses でサニタイズして出力する。get_breadcrumb() で生成した <nav> / aria-current が
+	 * 剥がされないよう、許可リストに nav タグと aria-current 属性を含めている。
 	 */
 	public static function the_breadcrumb() {
 		$allowed_html = array(
+			// ナビゲーションランドマーク。aria-label が剥がされないよう許可する。
+			'nav'  => array(
+				'id'         => array(),
+				'class'      => array(),
+				'aria-label' => array(),
+			),
 			'div'  => array(
 				'id'        => array(),
 				'class'     => array(),
@@ -474,11 +498,13 @@ class VkBreadcrumb {
 				'itemprop' => array(),
 			),
 			'span' => array(
-				'id'        => array(),
-				'class'     => array(),
-				'itemprop'  => array(),
-				'itemscope' => array(),
-				'itemtype'  => array(),
+				'id'          => array(),
+				'class'       => array(),
+				'itemprop'    => array(),
+				'itemscope'   => array(),
+				'itemtype'    => array(),
+				// 現在ページを示す aria-current が剥がされないよう許可する。
+				'aria-current' => array(),
 			),
 			'i'    => array(
 				'id'    => array(),

--- a/tests/test-vk-breadcrumb.php
+++ b/tests/test-vk-breadcrumb.php
@@ -759,6 +759,10 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 			'post_parent'  => $parent_page_id,
 		) );
 
+		// aria-current="page" が <li> 開始タグの中に付くことを検証する正規表現。
+		// （span ではなく li に付与する設計のため、開始タグ <li ... aria-current="page"> を期待する）
+		$li_aria_current_regex = '/<li[^>]*aria-current="page"/';
+
 		$test_cases = array(
 			array(
 				'test_condition_name' => '子固定ページ表示時 => <nav> と aria-label が出力される',
@@ -768,30 +772,34 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 					'aria-label=',
 				),
 				'expected_not_contains' => array(),
+				'expected_li_aria_current' => true,
 			),
 			array(
-				'test_condition_name' => '子固定ページ表示時 => 最後の要素（現在ページ）に aria-current="page" が付く',
+				'test_condition_name' => '子固定ページ表示時 => 最後の要素（現在ページ）の <li> に aria-current="page" が付く',
 				'target_url'          => get_permalink( $child_page_id ),
 				'expected_contains'   => array(
 					'aria-current="page"',
 				),
 				'expected_not_contains' => array(),
+				'expected_li_aria_current' => true,
 			),
 			array(
-				'test_condition_name' => '親固定ページ（リンクなし末端）でも aria-current="page" が付く',
+				'test_condition_name' => '親固定ページ（リンクなし末端）でも <li> に aria-current="page" が付く',
 				'target_url'          => get_permalink( $parent_page_id ),
 				'expected_contains'   => array(
 					'aria-current="page"',
 				),
 				'expected_not_contains' => array(),
+				'expected_li_aria_current' => true,
 			),
 			array(
-				'test_condition_name' => 'トップページ（HOME1項目のみ）でも <nav> は出力される',
+				'test_condition_name' => 'トップページ（HOME1項目のみ）でも <nav> と唯一の <li> の aria-current が出力される',
 				'target_url'          => home_url(),
 				'expected_contains'   => array(
 					'<nav ',
 				),
 				'expected_not_contains' => array(),
+				'expected_li_aria_current' => true,
 			),
 		);
 
@@ -804,6 +812,10 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 			}
 			foreach ( $case['expected_not_contains'] as $needle ) {
 				$this->assertStringNotContainsString( $needle, $html, $case['test_condition_name'] . ' / 含まれてはいけない文字列: ' . $needle );
+			}
+			// aria-current が <li> 開始タグに付いていることを正規表現で検証する。
+			if ( ! empty( $case['expected_li_aria_current'] ) ) {
+				$this->assertMatchesRegularExpression( $li_aria_current_regex, $html, $case['test_condition_name'] . ' / <li> に aria-current="page" が付くこと' );
 			}
 		}
 
@@ -836,23 +848,28 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 			'post_parent'  => $parent_page_id,
 		) );
 
+		// wp_kses 通過後も aria-current が <li> に残ることを検証する正規表現。
+		$li_aria_current_regex = '/<li[^>]*aria-current="page"/';
+
 		$test_cases = array(
 			array(
-				'test_condition_name' => 'the_breadcrumb() は wp_kses 後も <nav aria-label を出力する',
+				'test_condition_name' => 'the_breadcrumb() は wp_kses 後も <nav aria-label と <li の aria-current を出力する',
 				'target_url'          => get_permalink( $child_page_id ),
 				'expected_contains'   => array(
 					'<nav ',
 					'aria-label=',
 					'aria-current="page"',
 				),
+				'expected_li_aria_current' => true,
 			),
 			array(
-				'test_condition_name' => '境界値: トップページのみのパンくずでも <nav> が出力される',
+				'test_condition_name' => '境界値: トップページのみのパンくずでも <nav> と <li の aria-current が出力される',
 				'target_url'          => home_url(),
 				'expected_contains'   => array(
 					'<nav ',
 					'</nav>',
 				),
+				'expected_li_aria_current' => true,
 			),
 		);
 
@@ -866,6 +883,10 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 
 			foreach ( $case['expected_contains'] as $needle ) {
 				$this->assertStringContainsString( $needle, $html, $case['test_condition_name'] . ' / 期待文字列: ' . $needle );
+			}
+			// wp_kses 後も aria-current が <li> 開始タグに残っていることを検証する。
+			if ( ! empty( $case['expected_li_aria_current'] ) ) {
+				$this->assertMatchesRegularExpression( $li_aria_current_regex, $html, $case['test_condition_name'] . ' / wp_kses 後も <li> に aria-current="page" が残ること' );
 			}
 		}
 

--- a/tests/test-vk-breadcrumb.php
+++ b/tests/test-vk-breadcrumb.php
@@ -816,6 +816,9 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 			// aria-current が <li> 開始タグに付いていることを正規表現で検証する。
 			if ( ! empty( $case['expected_li_aria_current'] ) ) {
 				$this->assertMatchesRegularExpression( $li_aria_current_regex, $html, $case['test_condition_name'] . ' / <li> に aria-current="page" が付くこと' );
+				// 現在ページは1つだけなので、aria-current="page" はちょうど1箇所であることまで固定する。
+				preg_match_all( $li_aria_current_regex, $html, $li_aria_current_matches );
+				$this->assertSame( 1, count( $li_aria_current_matches[0] ), $case['test_condition_name'] . ' / aria-current="page" が <li> にちょうど1箇所だけ付くこと' );
 			}
 		}
 
@@ -887,6 +890,9 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 			// wp_kses 後も aria-current が <li> 開始タグに残っていることを検証する。
 			if ( ! empty( $case['expected_li_aria_current'] ) ) {
 				$this->assertMatchesRegularExpression( $li_aria_current_regex, $html, $case['test_condition_name'] . ' / wp_kses 後も <li> に aria-current="page" が残ること' );
+				// 現在ページは1つだけなので、wp_kses 後も aria-current="page" はちょうど1箇所であることまで固定する。
+				preg_match_all( $li_aria_current_regex, $html, $li_aria_current_matches );
+				$this->assertSame( 1, count( $li_aria_current_matches[0] ), $case['test_condition_name'] . ' / wp_kses 後も aria-current="page" が <li> にちょうど1箇所だけ残ること' );
 			}
 		}
 

--- a/tests/test-vk-breadcrumb.php
+++ b/tests/test-vk-breadcrumb.php
@@ -822,6 +822,22 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 			}
 		}
 
+		// vk_breadcrumb_nav_aria_label フィルタで <nav> の aria-label を上書きできることを検証する。
+		// テスト間に漏れないよう、検証後に必ず remove_filter() で外す。
+		$custom_aria_label = 'カスタムパンくず';
+		$aria_label_filter = function () use ( $custom_aria_label ) {
+			return $custom_aria_label;
+		};
+		add_filter( 'vk_breadcrumb_nav_aria_label', $aria_label_filter );
+		$this->go_to( get_permalink( $child_page_id ) );
+		$filtered_html = VkBreadcrumb::get_breadcrumb();
+		remove_filter( 'vk_breadcrumb_nav_aria_label', $aria_label_filter );
+		$this->assertStringContainsString(
+			'<nav aria-label="' . $custom_aria_label . '">',
+			$filtered_html,
+			'vk_breadcrumb_nav_aria_label フィルタで <nav> の aria-label を上書きできること'
+		);
+
 		// テストデータを削除
 		wp_delete_post( $child_page_id, true );
 		wp_delete_post( $parent_page_id, true );

--- a/tests/test-vk-breadcrumb.php
+++ b/tests/test-vk-breadcrumb.php
@@ -737,4 +737,140 @@ class VkBreadcrumbTest extends WP_UnitTestCase {
 		update_option( 'page_on_front', $before_page_on_front );
 		update_option( 'show_on_front', $before_show_on_front );
 	}
+
+	/**
+	 * get_breadcrumb() の HTML 出力に <nav> ランドマークと aria-current が含まれるか検証する。
+	 */
+	function test_get_breadcrumb() {
+
+		// テスト用の固定ページを作成（親・子の2階層）
+		$parent_page_id = wp_insert_post( array(
+			'post_title'   => 'a11y-parent-page',
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_content' => 'content',
+		) );
+
+		$child_page_id = wp_insert_post( array(
+			'post_title'   => 'a11y-child-page',
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_content' => 'content',
+			'post_parent'  => $parent_page_id,
+		) );
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '子固定ページ表示時 => <nav> と aria-label が出力される',
+				'target_url'          => get_permalink( $child_page_id ),
+				'expected_contains'   => array(
+					'<nav ',
+					'aria-label=',
+				),
+				'expected_not_contains' => array(),
+			),
+			array(
+				'test_condition_name' => '子固定ページ表示時 => 最後の要素（現在ページ）に aria-current="page" が付く',
+				'target_url'          => get_permalink( $child_page_id ),
+				'expected_contains'   => array(
+					'aria-current="page"',
+				),
+				'expected_not_contains' => array(),
+			),
+			array(
+				'test_condition_name' => '親固定ページ（リンクなし末端）でも aria-current="page" が付く',
+				'target_url'          => get_permalink( $parent_page_id ),
+				'expected_contains'   => array(
+					'aria-current="page"',
+				),
+				'expected_not_contains' => array(),
+			),
+			array(
+				'test_condition_name' => 'トップページ（HOME1項目のみ）でも <nav> は出力される',
+				'target_url'          => home_url(),
+				'expected_contains'   => array(
+					'<nav ',
+				),
+				'expected_not_contains' => array(),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$this->go_to( $case['target_url'] );
+			$html = VkBreadcrumb::get_breadcrumb();
+
+			foreach ( $case['expected_contains'] as $needle ) {
+				$this->assertStringContainsString( $needle, $html, $case['test_condition_name'] . ' / 期待文字列: ' . $needle );
+			}
+			foreach ( $case['expected_not_contains'] as $needle ) {
+				$this->assertStringNotContainsString( $needle, $html, $case['test_condition_name'] . ' / 含まれてはいけない文字列: ' . $needle );
+			}
+		}
+
+		// テストデータを削除
+		wp_delete_post( $child_page_id, true );
+		wp_delete_post( $parent_page_id, true );
+	}
+
+	/**
+	 * the_breadcrumb() が wp_kses 通過後も <nav> と aria-current を出力するか検証する。
+	 *
+	 * wp_kses の許可リストに nav / aria-label / aria-current が追加されていなければ
+	 * これらの属性・タグが剥がされてしまう。
+	 */
+	function test_the_breadcrumb() {
+
+		// テスト用の固定ページを2つ作成
+		$parent_page_id = wp_insert_post( array(
+			'post_title'   => 'kses-parent-page',
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_content' => 'content',
+		) );
+
+		$child_page_id = wp_insert_post( array(
+			'post_title'   => 'kses-child-page',
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+			'post_content' => 'content',
+			'post_parent'  => $parent_page_id,
+		) );
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'the_breadcrumb() は wp_kses 後も <nav aria-label を出力する',
+				'target_url'          => get_permalink( $child_page_id ),
+				'expected_contains'   => array(
+					'<nav ',
+					'aria-label=',
+					'aria-current="page"',
+				),
+			),
+			array(
+				'test_condition_name' => '境界値: トップページのみのパンくずでも <nav> が出力される',
+				'target_url'          => home_url(),
+				'expected_contains'   => array(
+					'<nav ',
+					'</nav>',
+				),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			$this->go_to( $case['target_url'] );
+
+			// the_breadcrumb() は echo するため ob_start() でキャプチャする
+			ob_start();
+			VkBreadcrumb::the_breadcrumb();
+			$html = ob_get_clean();
+
+			foreach ( $case['expected_contains'] as $needle ) {
+				$this->assertStringContainsString( $needle, $html, $case['test_condition_name'] . ' / 期待文字列: ' . $needle );
+			}
+		}
+
+		// テストデータを削除
+		wp_delete_post( $child_page_id, true );
+		wp_delete_post( $parent_page_id, true );
+	}
 }


### PR DESCRIPTION
## 概要

パンくずリスト共通ライブラリ vk-breadcrumb に、スクリーンリーダー向けのアクセシビリティ対応を追加します。

- パンくず全体を `<nav aria-label="...">`（ナビゲーション領域を示すランドマーク要素）で囲み、画面読み上げソフトの利用者がパンくずをナビゲーション領域として認識・ジャンプ移動できるようにする
- 現在表示中のページ（パンくずの最後の項目）の `<li>` に `aria-current="page"`（現在地を示す属性）を付与し、「今いるページ」を読み上げ利用者に明示する
- 既存の Schema.org microdata（検索エンジン向けの構造化データ）は**変更せずそのまま維持**

検索向けの構造化データは実装済みでしたが、これはランドマーク（読み上げソフトが領域として扱う目印）にはならないため、`<nav>` と `aria-current` を追加で補います。

参照: WCAG 2.4.8（現在位置）/ 1.3.1（情報及び関係性）/ WAI-ARIA breadcrumb pattern

関連Issue: vektor-inc/multi-repo-tasks#20

## 変更点

- `src/VkBreadcrumb.php`
  - `get_breadcrumb()`（パンくずの HTML を生成するメソッド）: 最も外側を `<nav aria-label="...">` で囲む。aria-label の値は翻訳可能（`__( 'Breadcrumb', 'lightning' )`）かつフィルタ `vk_breadcrumb_nav_aria_label` で上書き可能
  - 現在ページ（パンくず配列の最後の要素）の `<li>` に `aria-current="page"` を付与（リンクの有無に関わらず「最後の項目＝現在地」が構造的に明確になるよう `<li>` 側に付与）
  - `the_breadcrumb()`（`wp_kses` でサニタイズして出力するメソッド）の許可リスト（`$allowed_html`）に `nav` タグ・`aria-label` 属性・`aria-current` 属性を追加（許可リストに無いと出力時に剥がされるため）
- `tests/test-vk-breadcrumb.php`: PHPUnit テストを追加
- `README.md`: changelog 追記

## 既存への影響

- **見た目の変化なし**（`<nav>` は余白を持たないブロック要素。既存の id / class / microdata はすべて維持）
- 出力 HTML に `<nav>` ラッパーと属性が追加されるが、この変更は共通ライブラリのため、**各製品（Lightning G3、vk-blocks-pro のパンくずブロック等）が composer 依存を更新するまで実出力には反映されない**段階的な反映
- このライブラリを `new VkBreadcrumb()` 経由で使う Lightning G3・vk-blocks-pro のパンくずブロックに波及。独自テンプレートでパンくずを描画している lightning-pro / Lightning G2 はこのライブラリ経由ではないため、別途対応（multi-repo-tasks#20 配下の別 PR で実施予定）

## テスト（確認手順）

### 1. 自動テスト（PHPUnit）

このリポジトリの PHPUnit を実行する。

```
npm install
composer install
wp-env start
npm run phpunit
```

→ `get_breadcrumb()` / `the_breadcrumb()` の出力に `<nav` と `aria-label`、現在ページの `<li>` に `aria-current="page"` が含まれることを検証するテストが追加されており、すべて成功する（3 tests / 36 assertions が green）。

### 2. 実際の出力での確認（任意・このライブラリを使うテーマで確認する場合）

このライブラリ単体は画面を持たないため、ライブラリを利用するテーマ（Lightning G3）で確認する場合の手順です。

1. Lightning G3 がインストールされた WordPress 環境で、テーマの `vendor/vektor-inc/vk-breadcrumb` をこのブランチの内容に差し替える（composer で当ブランチを参照、またはファイルを差し替え）
2. パンくずが表示される固定ページまたは投稿を開く
3. ブラウザの開発者ツールで HTML を確認する
   - → パンくず全体が `<nav aria-label="Breadcrumb">`（日本語環境では翻訳により「パンくず」等）で囲まれている
   - → 最後の項目（現在ページ）の `<li>` に `aria-current="page"` が付いている
   - → 既存の `itemtype="...BreadcrumbList"` などの microdata がそのまま残っている

### 3. アクセシビリティの確認（推奨）

1. 上記の固定ページで Chrome DevTools を開き、要素（Elements）パネルから対象要素を選び **Accessibility（アクセシビリティ）パネル** を開く
2. ランドマークツリー（Landmarks）を確認する
   - → パンくずが `navigation`（ナビゲーション）ランドマークとして認識され、ラベル（aria-label の値）が表示される
   - → 現在ページの要素に `current: page` が表示される

別の確認手段として、スクリーンリーダー（macOS の VoiceOver / Windows の NVDA）でランドマーク移動した際にパンくずナビゲーションへジャンプでき、現在ページが「現在のページ」と読み上げられることでも確認できます。

### デグレ確認

- パンくずの**見た目（レイアウト・余白・リンク）が変わっていない**こと
- 既存の microdata（構造化データ）が維持され、Google のリッチリザルトテスト等で BreadcrumbList が引き続き認識されること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * パンくずを `nav` のランドマークとして出力し、`aria-label` をフィルタで上書きできるようになりました。  
* **アクセシビリティ改善**
  * 現在ページのパンくず要素（最終要素）に `aria-current="page"` を付与し、対象を1箇所に限定しました。  
* **テスト**
  * `nav` の `aria-label`、`aria-current="page"` の出現位置と1箇所化、フィルタ上書きを検証するテストを追加しました。  
* **ドキュメント**
  * 変更履歴（Change log）に 0.2.8 の内容を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->