### PR TITLE
[ 開発環境 ] vk-breadcrumb テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,10 +1,13 @@
 name: phpunit
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
 
 jobs:
   test:
 
+    if: contains(github.event.pull_request.labels.*.name, 'run-ci')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 概要
GitHub Actions の消費削減のため、PHPUnit テストを `run-ci` ラベル付き PR のときのみ実行するように変更しました。

## 変更内容
- `.github/workflows/phpunit.yml`
  - `on: pull_request` を `types: [opened, reopened, labeled, synchronize]` 付きに展開
  - `test` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加
  - （元々 push トリガーは無し）

## 確認手順
1. ラベル無しの PR ではテストワークフローが起動しないこと
2. `run-ci` ラベルを付与するとテストワークフローが起動すること
3. push（ブランチへの push）ではテストワークフローが起動しないこと
4. リリース時（該当する場合）は従来どおりテストが実行されること

CI 設定のみの変更でプラグイン動作に影響はありません。

関連: vektor-inc/multi-repo-tasks#24
